### PR TITLE
Add new NavigationStack widget

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -173,6 +173,7 @@ impl LiveHook for App {
         crate::shared::header::live_design(cx);
         crate::shared::search_bar::live_design(cx);
         crate::shared::dropdown_menu::live_design(cx);
+        crate::shared::stack_navigation::live_design(cx);
 
         // home - chats
         crate::home::home_screen::live_design(cx);
@@ -182,7 +183,7 @@ impl LiveHook for App {
         crate::contacts::contacts_screen::live_design(cx);
         crate::contacts::contacts_group::live_design(cx);
         crate::contacts::contacts_list::live_design(cx);
-        crate::contacts::new_contact::live_design(cx);
+        crate::contacts::add_contact_screen::live_design(cx);
 
         // profile
         crate::profile::profile_screen::live_design(cx);

--- a/src/contacts/add_contact_screen.rs
+++ b/src/contacts/add_contact_screen.rs
@@ -1,0 +1,12 @@
+use makepad_widgets::widget::WidgetCache;
+use makepad_widgets::*;
+
+live_design! {
+    import makepad_widgets::frame::*;
+    import crate::shared::search_bar::SearchBar;
+
+    AddContactScreen = <Frame> {
+        walk: {width: Fill, height: Fill}
+        <SearchBar> {}
+    }
+}

--- a/src/contacts/mod.rs
+++ b/src/contacts/mod.rs
@@ -2,4 +2,4 @@ pub mod contact_info;
 pub mod contacts_group;
 pub mod contacts_list;
 pub mod contacts_screen;
-pub mod new_contact;
+pub mod add_contact_screen;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -2,4 +2,5 @@ pub mod dropdown_menu;
 pub mod header;
 pub mod helpers;
 pub mod search_bar;
+pub mod stack_navigation;
 pub mod styles;

--- a/src/shared/stack_navigation.rs
+++ b/src/shared/stack_navigation.rs
@@ -28,6 +28,7 @@ live_design! {
     StackNavigationView = {{StackNavigationView}} {
         walk: {width: Fill, height: Fill}
         frame: <Frame> {
+            visible: false
             walk: {width: Fill, height: Fill}
             layout: {flow: Down}
             show_bg: true
@@ -38,18 +39,20 @@ live_design! {
             header = <Header> {}
         }
 
-        offset: 500.0
+        // TBD Adjust this based on actual screen size
+        offset: 1000.0
 
         state: {
             slide = {
                 default: hide,
                 hide = {
-                    from: {all: Forward {duration: 0.2}}
-                    apply: {offset: 500.0}
+                    from: {all: Forward {duration: 0.6}}
+                    // Bug: Constants are not working as part of an live state value
+                    apply: {offset: 1000.0}
                 }
 
                 show = {
-                    from: {all: Forward {duration: 0.2}}
+                    from: {all: Forward {duration: 0.6}}
                     apply: {offset: 0.0}
                 }
             }
@@ -141,6 +144,11 @@ impl StackNavigationView {
         for action in actions.into_iter() {
             dispatch_action(cx, action);
         }
+
+        if self.state.is_in_state(cx, id!(slide.hide)) &&
+            !self.state.is_track_animating(cx, id!(slide)) {
+                self.apply_over(cx, live!{frame: {visible: false}});
+        }
     }
 }
 
@@ -150,6 +158,7 @@ pub struct StackNavigationViewRef(pub WidgetRef);
 impl StackNavigationViewRef {
     pub fn show(&mut self, cx: &mut Cx) {
         if let Some(mut inner) = self.borrow_mut() {
+            inner.apply_over(cx, live!{frame: {visible: true}});
             inner.animate_state(cx, id!(slide.show));
         }
     }


### PR DESCRIPTION
This PR extracts functionality from the former `NewContact` widget to a more specific `NavigationStack`. So the behavior to open a new screen stacked over another view is separated from the Add Contact section of the app.

The new widget includes:

* `NavigationStack` has a simple `Frame` called `root_view`, which is the view where the navigation is originated.
* `NavigationStack` has a `NavigationStackView` called `stack_view`. It includes a header with a title and a "back button" that will close this view.
* `NavigationStack` API has a `show_stack_view` public function as a mechanism for devs to make the "stack view" show up (over the root view).

In overall, the widget provides two spots (root and stack view) and the mechanism to open/close the stack view.