### PR TITLE
Fix get_item() calls

### DIFF
--- a/src/contacts/contacts_list.rs
+++ b/src/contacts/contacts_list.rs
@@ -213,7 +213,7 @@ impl ContactsList {
                     x if x == groups_count + 2 => id!(bottom),
                     _ => id!(contacts_group),
                 };
-                let item = self.list_view.get_item(cx, item_id, template).unwrap();
+                let item = self.list_view.get_item(cx, item_id, template[0]).unwrap();
 
                 if item_id >= 2 && item_id < groups_count + 2 {
                     let group = &grouped_data[(item_id - 2) as usize];

--- a/src/home/chat_list.rs
+++ b/src/home/chat_list.rs
@@ -181,7 +181,7 @@ impl ChatList {
                     _ => id!(chat),
                 };
 
-                let item = self.list_view.get_item(cx, item_id, template).unwrap();
+                let item = self.list_view.get_item(cx, item_id, template[0]).unwrap();
 
                 if item_id >= 1 && item_id < chat_entries_count + 1 {
                     let item_index = item_id as usize - 1; // offset by 1 to account for the search bar


### PR DESCRIPTION
get_item() now expects a `LiveId` instead of `&[LiveId; 1]`