### PR TITLE
Fix for new makepad version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,7 +47,6 @@ dependencies = [
 name = "makepad-draw"
 version = "0.3.0"
 dependencies = [
- "makepad-image-formats",
  "makepad-platform",
  "makepad-vector",
  "rustybuzz",
@@ -58,10 +63,6 @@ version = "0.1.0"
 
 [[package]]
 name = "makepad-futures-legacy"
-version = "0.3.0"
-
-[[package]]
-name = "makepad-image-formats"
 version = "0.3.0"
 
 [[package]]
@@ -129,7 +130,6 @@ version = "0.3.0"
 dependencies = [
  "makepad-futures",
  "makepad-futures-legacy",
- "makepad-image-formats",
  "makepad-objc-sys",
  "makepad-shader-compiler",
  "makepad-wasm-bridge",
@@ -164,6 +164,8 @@ version = "0.3.0"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
+ "makepad-zune-jpeg",
+ "makepad-zune-png",
 ]
 
 [[package]]
@@ -180,6 +182,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "makepad-zune-core"
+version = "0.2.14"
+dependencies = [
+ "bitflags 2.4.0",
+]
+
+[[package]]
+name = "makepad-zune-inflate"
+version = "0.2.54"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "makepad-zune-jpeg"
+version = "0.3.17"
+dependencies = [
+ "makepad-zune-core",
+]
+
+[[package]]
+name = "makepad-zune-png"
+version = "0.2.1"
+dependencies = [
+ "makepad-zune-core",
+ "makepad-zune-inflate",
+]
+
+[[package]]
 name = "makepad_wechat"
 version = "0.1.0"
 dependencies = [
@@ -192,7 +223,7 @@ name = "rustybuzz"
 version = "0.8.0"
 source = "git+https://github.com/RazrFalcon/rustybuzz?rev=a0b8aa3#a0b8aa3ed002550cfea1137655d9ab7569964ae5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "smallvec",
  "ttf-parser",
@@ -201,6 +232,12 @@ dependencies = [
  "unicode-properties",
  "unicode-script",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"

--- a/src/app.rs
+++ b/src/app.rs
@@ -297,17 +297,11 @@ impl AppMain for App {
             match action.action() {
                 StackViewAction::ShowMoments => {
                     ui.get_stack_navigation(id!(navigation))
-                        .show_stack_view_by_id(
-                            LiveId::from_str_with_lut("moments_stack_view").unwrap(),
-                            cx,
-                        );
+                        .show_stack_view_by_id(LiveId::from_str("moments_stack_view"), cx);
                 }
                 StackViewAction::ShowMyProfile => {
                     ui.get_stack_navigation(id!(navigation))
-                        .show_stack_view_by_id(
-                            LiveId::from_str_with_lut("my_profile_stack_view").unwrap(),
-                            cx,
-                        );
+                        .show_stack_view_by_id(LiveId::from_str("my_profile_stack_view"), cx);
                 }
                 _ => {}
             }
@@ -316,10 +310,7 @@ impl AppMain for App {
                 DropDownAction::Select(_id, value) => {
                     if LiveValue::Bool(true) == value.enum_eq(id!(AddContact)) {
                         ui.get_stack_navigation(id!(navigation))
-                            .show_stack_view_by_id(
-                                LiveId::from_str_with_lut("add_contact_stack_view").unwrap(),
-                                cx,
-                            );
+                            .show_stack_view_by_id(LiveId::from_str("add_contact_stack_view"), cx);
                     }
                 }
                 _ => {}
@@ -341,10 +332,7 @@ impl AppMain for App {
                         .get_chat(id!(chat));
                     chat_ref.set_chat_id(id);
 
-                    stack_navigation.show_stack_view_by_id(
-                        LiveId::from_str_with_lut("chat_stack_view").unwrap(),
-                        cx,
-                    );
+                    stack_navigation.show_stack_view_by_id(LiveId::from_str("chat_stack_view"), cx);
                 }
                 _ => {}
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -297,12 +297,15 @@ impl AppMain for App {
             match action.action() {
                 StackViewAction::ShowMoments => {
                     ui.get_stack_navigation(id!(navigation))
-                        .show_stack_view_by_id(LiveId::from_str("moments_stack_view").unwrap(), cx);
+                        .show_stack_view_by_id(
+                            LiveId::from_str_with_lut("moments_stack_view").unwrap(),
+                            cx,
+                        );
                 }
                 StackViewAction::ShowMyProfile => {
                     ui.get_stack_navigation(id!(navigation))
                         .show_stack_view_by_id(
-                            LiveId::from_str("my_profile_stack_view").unwrap(),
+                            LiveId::from_str_with_lut("my_profile_stack_view").unwrap(),
                             cx,
                         );
                 }
@@ -314,7 +317,7 @@ impl AppMain for App {
                     if LiveValue::Bool(true) == value.enum_eq(id!(AddContact)) {
                         ui.get_stack_navigation(id!(navigation))
                             .show_stack_view_by_id(
-                                LiveId::from_str("add_contact_stack_view").unwrap(),
+                                LiveId::from_str_with_lut("add_contact_stack_view").unwrap(),
                                 cx,
                             );
                     }
@@ -338,8 +341,10 @@ impl AppMain for App {
                         .get_chat(id!(chat));
                     chat_ref.set_chat_id(id);
 
-                    stack_navigation
-                        .show_stack_view_by_id(LiveId::from_str("chat_stack_view").unwrap(), cx);
+                    stack_navigation.show_stack_view_by_id(
+                        LiveId::from_str_with_lut("chat_stack_view").unwrap(),
+                        cx,
+                    );
                 }
                 _ => {}
             }

--- a/src/contacts/contacts_group.rs
+++ b/src/contacts/contacts_group.rs
@@ -140,7 +140,7 @@ impl ContactsGroup {
         let _ = self.header.draw_walk_widget(cx, walk);
 
         for contact in self.data.iter() {
-            let contact_widget_id = LiveId::from_str(&contact.name).unwrap().into();
+            let contact_widget_id = LiveId::from_str_with_lut(&contact.name).unwrap().into();
             let current_contact = self.contacts.get_or_insert(cx, contact_widget_id, |cx| {
                 let template = match contact.kind {
                     ContactKind::People => self.people_contact_template,

--- a/src/contacts/contacts_group.rs
+++ b/src/contacts/contacts_group.rs
@@ -140,7 +140,7 @@ impl ContactsGroup {
         let _ = self.header.draw_walk_widget(cx, walk);
 
         for contact in self.data.iter() {
-            let contact_widget_id = LiveId::from_str_with_lut(&contact.name).unwrap().into();
+            let contact_widget_id = LiveId::from_str(&contact.name).into();
             let current_contact = self.contacts.get_or_insert(cx, contact_widget_id, |cx| {
                 let template = match contact.kind {
                     ContactKind::People => self.people_contact_template,


### PR DESCRIPTION
update LiveId::from_str() calls to use the new LiveId::from_str_with_lut()